### PR TITLE
Introduce User-Defined Literals for coordinates

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -15,7 +15,6 @@ env:
   CCACHE_TEMPDIR: /tmp/.ccache-temp
   CCACHE_COMPRESS: 1
   CASHER_TIME_OUT: 599 # one second less than 10m to avoid 10m timeout error: https://github.com/Project-OSRM/osrm-backend/issues/2742
-  CMAKE_VERSION: 3.21.2
   ENABLE_NODE_BINDINGS: "ON"
 
 concurrency:
@@ -31,7 +30,10 @@ jobs:
       BUILD_TYPE: Release
     steps:
     - uses: actions/checkout@v4
-    - run: cmake --version
+    - name: Fix cmake 4.x compatibility issue
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
     - uses: actions/setup-node@v4
       with:
         node-version: 18
@@ -57,7 +59,7 @@ jobs:
 
         cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_CONAN=ON -DENABLE_NODE_BINDINGS=ON ..
         cmake --build . --config Release
-        
+
     # TODO: MSVC goes out of memory when building our tests
     # - name: Run tests
     #   shell: bash
@@ -97,6 +99,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Fix cmake 4.x compatibility issue
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
@@ -130,6 +136,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - name: Fix cmake 4.x compatibility issue
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Enable osm.pbf cache
         uses: actions/cache@v4
         with:
@@ -331,7 +341,7 @@ jobs:
             build_node_package: true
             continue-on-error: true
             node: 22
-            runs-on: macos-15 # arm64 
+            runs-on: macos-15 # arm64
             BUILD_TYPE: Release
             CCOMPILER: clang
             CXXCOMPILER: clang++
@@ -362,6 +372,10 @@ jobs:
       ENABLE_LTO: ${{ matrix.ENABLE_LTO }}
     steps:
     - uses: actions/checkout@v4
+    - name: Fix cmake 4.x compatibility issue
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
     - name: Build machine architecture
       run: uname -m
     - name: Use Node.js
@@ -419,7 +433,7 @@ jobs:
         fi
     # See: https://github.com/actions/toolkit/issues/946#issuecomment-1590016041
     # We need it to be able to access system folders while restoring cached Boost below
-    - name: Give tar root ownership 
+    - name: Give tar root ownership
       if: runner.os == 'Linux' && matrix.ENABLE_CONAN != 'ON'
       run: sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
@@ -429,7 +443,7 @@ jobs:
       id: install-boost
       with:
         boost_version: 1.85.0
-    
+
     - name: Install dev dependencies
       run: |
         # workaround for issue that GitHub Actions seems to not adding it to PATH after https://github.com/actions/runner-images/pull/6499
@@ -498,6 +512,7 @@ jobs:
         fi
 
         ccache --zero-stats
+        cmake --version
         cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
                  -DENABLE_CONAN=${ENABLE_CONAN:-OFF} \
                  -DENABLE_ASSERTIONS=${ENABLE_ASSERTIONS:-OFF} \

--- a/include/engine/guidance/route_step.hpp
+++ b/include/engine/guidance/route_step.hpp
@@ -43,7 +43,7 @@ struct IntermediateIntersection
 
 inline IntermediateIntersection getInvalidIntersection()
 {
-    return {util::Coordinate{util::FloatLongitude{0.0}, util::FloatLatitude{0.0}},
+    return {{},
             {},
             {},
             IntermediateIntersection::NO_INDEX,

--- a/include/engine/guidance/step_maneuver.hpp
+++ b/include/engine/guidance/step_maneuver.hpp
@@ -30,12 +30,7 @@ struct StepManeuver
 
 inline StepManeuver getInvalidStepManeuver()
 {
-    return {util::Coordinate{util::FloatLongitude{0.0}, util::FloatLatitude{0.0}},
-            0,
-            0,
-            osrm::guidance::TurnInstruction::NO_TURN(),
-            WaypointType::None,
-            0};
+    return {{}, 0, 0, osrm::guidance::TurnInstruction::NO_TURN(), WaypointType::None, 0};
 }
 
 } // namespace osrm::engine::guidance

--- a/include/engine/polyline_compressor.hpp
+++ b/include/engine/polyline_compressor.hpp
@@ -68,9 +68,9 @@ std::vector<util::Coordinate> decodePolyline(const std::string &polyline)
         latitude += dlat;
         longitude += dlon;
 
-        coordinates.emplace_back(util::Coordinate{
+        coordinates.emplace_back(
             util::FixedLongitude{static_cast<std::int32_t>(longitude * polyline_to_coordinate)},
-            util::FixedLatitude{static_cast<std::int32_t>(latitude * polyline_to_coordinate)}});
+            util::FixedLatitude{static_cast<std::int32_t>(latitude * polyline_to_coordinate)});
     }
     return coordinates;
 }

--- a/include/osrm/coordinate.hpp
+++ b/include/osrm/coordinate.hpp
@@ -39,6 +39,7 @@ using util::FloatLatitude;
 using util::FloatLongitude;
 using util::toFixed;
 using util::toFloating;
+using namespace util::literals;
 } // namespace osrm
 
 #endif

--- a/include/util/coordinate.hpp
+++ b/include/util/coordinate.hpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <complex>
 #include <cstdint>
 #include <type_traits>
 
@@ -192,7 +193,11 @@ struct Coordinate
     FixedLongitude lon;
     FixedLatitude lat;
 
-    Coordinate() : lon{std::numeric_limits<int>::min()}, lat{std::numeric_limits<int>::min()} {}
+    Coordinate() : lon{0}, lat{0} {}
+
+    constexpr Coordinate(std::complex<double> coord)
+        : lon{static_cast<std::int32_t>(coord.real() * COORDINATE_PRECISION)},
+          lat{static_cast<std::int32_t>(coord.imag() * COORDINATE_PRECISION)} {};
 
     Coordinate(const FloatCoordinate &other);
 
@@ -207,16 +212,6 @@ struct Coordinate
     }
 
     Coordinate(const FixedLongitude lon_, const FixedLatitude lat_) : lon(lon_), lat(lat_) {}
-
-    template <class T> Coordinate(const T &coordinate) : lon(coordinate.lon), lat(coordinate.lat)
-    {
-        static_assert(!std::is_same<T, Coordinate>::value,
-                      "This constructor should not be used for Coordinates");
-        static_assert(std::is_same<decltype(lon), decltype(coordinate.lon)>::value,
-                      "coordinate types incompatible");
-        static_assert(std::is_same<decltype(lat), decltype(coordinate.lat)>::value,
-                      "coordinate types incompatible");
-    }
 
     bool IsValid() const;
     friend bool operator==(const Coordinate lhs, const Coordinate rhs);
@@ -241,10 +236,9 @@ struct FloatCoordinate
     FloatLongitude lon;
     FloatLatitude lat;
 
-    FloatCoordinate()
-        : lon{std::numeric_limits<double>::min()}, lat{std::numeric_limits<double>::min()}
-    {
-    }
+    FloatCoordinate() : lon{0}, lat{0} {}
+
+    constexpr FloatCoordinate(std::complex<double> coord) : lon{coord.real()}, lat{coord.imag()} {}
 
     FloatCoordinate(const Coordinate other)
         : FloatCoordinate(toFloating(other.lon), toFloating(other.lat))
@@ -270,7 +264,68 @@ inline Coordinate::Coordinate(const FloatCoordinate &other)
     : Coordinate(toFixed(other.lon), toFixed(other.lat))
 {
 }
+
+inline namespace literals
+{
+
+// Usage: Coordinate coord;
+//        coord =  42_lat + 69.123456_lon
+//        coord = -42_lat - 69.123456_lon
+//        coord =  42_N + 69.123456_E
+//        coord =  42_S + 69.123456_W
+
+constexpr std::complex<double> operator""_lon(long double lon)
+{
+    return {static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_lat(long double lat)
+{
+    return {0, static_cast<double>(lat)};
+}
+constexpr std::complex<double> operator""_E(long double lon)
+{
+    return {static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_W(long double lon)
+{
+    return {-static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_N(long double lat)
+{
+    return {0, static_cast<double>(lat)};
+}
+constexpr std::complex<double> operator""_S(long double lat)
+{
+    return {0, -static_cast<double>(lat)};
+}
+constexpr std::complex<double> operator""_lon(unsigned long long int lon)
+{
+    return {static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_lat(unsigned long long int lat)
+{
+    return {0, static_cast<double>(lat)};
+}
+constexpr std::complex<double> operator""_E(unsigned long long int lon)
+{
+    return {static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_W(unsigned long long int lon)
+{
+    return {-static_cast<double>(lon), 0};
+}
+constexpr std::complex<double> operator""_N(unsigned long long int lat)
+{
+    return {0, static_cast<double>(lat)};
+}
+constexpr std::complex<double> operator""_S(unsigned long long int lat)
+{
+    return {0, -static_cast<double>(lat)};
+}
+} // namespace literals
+
 } // namespace util
+
 } // namespace osrm
 
 #endif /* COORDINATE_HPP_ */

--- a/src/benchmarks/bench.cpp
+++ b/src/benchmarks/bench.cpp
@@ -88,10 +88,10 @@ class GPSTraces
             }
 
             trackIDs.insert(trackID);
-            traces[trackID].emplace_back(osrm::util::Coordinate{
-                osrm::util::FloatLongitude{longitude}, osrm::util::FloatLatitude{latitude}});
-            coordinates.emplace_back(osrm::util::Coordinate{osrm::util::FloatLongitude{longitude},
-                                                            osrm::util::FloatLatitude{latitude}});
+            traces[trackID].emplace_back(osrm::util::FloatLongitude{longitude},
+                                         osrm::util::FloatLatitude{latitude});
+            coordinates.emplace_back(osrm::util::FloatLongitude{longitude},
+                                     osrm::util::FloatLatitude{latitude});
         }
 
         file.close();

--- a/src/benchmarks/match.cpp
+++ b/src/benchmarks/match.cpp
@@ -44,174 +44,88 @@ try
     params.overview = RouteParameters::OverviewType::False;
     params.steps = false;
 
-    using osrm::util::FloatCoordinate;
-    using osrm::util::FloatLatitude;
-    using osrm::util::FloatLongitude;
-
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.422176599502563}, FloatLatitude{43.73754595167546}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.421715259552002}, FloatLatitude{43.73744517900973}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.421489953994752}, FloatLatitude{43.73738316497729}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.421286106109619}, FloatLatitude{43.737274640266}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420910596847533}, FloatLatitude{43.73714285999499}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420696020126342}, FloatLatitude{43.73699557581948}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.42049217224121}, FloatLatitude{43.73690255404829}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420309782028198}, FloatLatitude{43.73672426191624}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420159578323363}, FloatLatitude{43.7366622471372}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420148849487305}, FloatLatitude{43.736623487867654}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419934272766113}, FloatLatitude{43.73647620241466}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419805526733398}, FloatLatitude{43.736228141885455}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419601678848267}, FloatLatitude{43.736142870841206}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419376373291015}, FloatLatitude{43.735956824504974}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419247627258301}, FloatLatitude{43.73574752168583}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419043779373169}, FloatLatitude{43.73566224995717}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418732643127442}, FloatLatitude{43.735406434042645}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418657541275024}, FloatLatitude{43.735321161828274}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418593168258667}, FloatLatitude{43.73521263337983}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418367862701416}, FloatLatitude{43.73508084857086}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418346405029297}, FloatLatitude{43.73484828643578}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4180567264556885}, FloatLatitude{43.734437424456566}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417809963226318}, FloatLatitude{43.73414284243448}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417863607406615}, FloatLatitude{43.73375523230292}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417809963226318}, FloatLatitude{43.73386376339265}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417895793914795}, FloatLatitude{43.73365445325776}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418067455291747}, FloatLatitude{43.73343739012297}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41803526878357}, FloatLatitude{43.73319706930599}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418024539947509}, FloatLatitude{43.73295674752463}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417906522750854}, FloatLatitude{43.73284821479115}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417917251586914}, FloatLatitude{43.7327551865773}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417434453964233}, FloatLatitude{43.73281720540258}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4173808097839355}, FloatLatitude{43.73307303237796}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41750955581665}, FloatLatitude{43.73328234454499}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417563199996948}, FloatLatitude{43.73352266501975}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41750955581665}, FloatLatitude{43.733770736756355}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417466640472412}, FloatLatitude{43.73409632935116}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417230606079102}, FloatLatitude{43.73428238146768}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41724133491516}, FloatLatitude{43.73405756842078}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4169838428497314}, FloatLatitude{43.73449168940785}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41701602935791}, FloatLatitude{43.734615723397525}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41704821586609}, FloatLatitude{43.73487929477265}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41725206375122}, FloatLatitude{43.734949063471895}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4173808097839355}, FloatLatitude{43.73533666587628}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41750955581665}, FloatLatitude{43.735623490040375}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417799234390259}, FloatLatitude{43.73577852955704}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4180781841278085}, FloatLatitude{43.735972328388435}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41850733757019}, FloatLatitude{43.73608860738618}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418850660324096}, FloatLatitude{43.736228141885455}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419086694717407}, FloatLatitude{43.73636767605958}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419333457946777}, FloatLatitude{43.73664674343239}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419633865356444}, FloatLatitude{43.73676302112054}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419784069061279}, FloatLatitude{43.737096349241845}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.420030832290649}, FloatLatitude{43.73720487427631}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419601678848267}, FloatLatitude{43.73708084564945}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419333457946777}, FloatLatitude{43.73708084564945}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.419043779373169}, FloatLatitude{43.737158363571325}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418915033340454}, FloatLatitude{43.737305647346446}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41848587989807}, FloatLatitude{43.7374916894919}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.418271303176879}, FloatLatitude{43.73746843425534}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417960166931152}, FloatLatitude{43.73744517900973}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417885065078735}, FloatLatitude{43.737212626056944}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417563199996948}, FloatLatitude{43.73703433484817}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4173057079315186}, FloatLatitude{43.73692580950463}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.417144775390625}, FloatLatitude{43.7367707729584}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416973114013672}, FloatLatitude{43.73653821738638}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416855096817017}, FloatLatitude{43.73639868360965}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.4167799949646}, FloatLatitude{43.736142870841206}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.41675853729248}, FloatLatitude{43.735848297208605}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416619062423706}, FloatLatitude{43.73567000193752}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416543960571288}, FloatLatitude{43.735406434042645}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416479587554932}, FloatLatitude{43.73529790574875}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416415214538574}, FloatLatitude{43.73515061703527}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416350841522218}, FloatLatitude{43.73490255101476}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416340112686156}, FloatLatitude{43.73475526132885}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416222095489501}, FloatLatitude{43.73446068087028}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416243553161621}, FloatLatitude{43.73430563794159}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.416050434112548}, FloatLatitude{43.73403431185051}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.415814399719239}, FloatLatitude{43.73382500231174}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.415750026702881}, FloatLatitude{43.73354592178871}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.415513992309569}, FloatLatitude{43.73347615145474}});
-    params.coordinates.push_back(
-        FloatCoordinate{FloatLongitude{7.415342330932617}, FloatLatitude{43.733251335381205}});
+    params.coordinates.push_back(7.422176599502563_lon + 43.73754595167546_lat);
+    params.coordinates.push_back(7.421715259552002_lon + 43.73744517900973_lat);
+    params.coordinates.push_back(7.421489953994752_lon + 43.73738316497729_lat);
+    params.coordinates.push_back(7.421286106109619_lon + 43.737274640266_lat);
+    params.coordinates.push_back(7.420910596847533_lon + 43.73714285999499_lat);
+    params.coordinates.push_back(7.420696020126342_lon + 43.73699557581948_lat);
+    params.coordinates.push_back(7.42049217224121_lon + 43.73690255404829_lat);
+    params.coordinates.push_back(7.420309782028198_lon + 43.73672426191624_lat);
+    params.coordinates.push_back(7.420159578323363_lon + 43.7366622471372_lat);
+    params.coordinates.push_back(7.420148849487305_lon + 43.736623487867654_lat);
+    params.coordinates.push_back(7.419934272766113_lon + 43.73647620241466_lat);
+    params.coordinates.push_back(7.419805526733398_lon + 43.736228141885455_lat);
+    params.coordinates.push_back(7.419601678848267_lon + 43.736142870841206_lat);
+    params.coordinates.push_back(7.419376373291015_lon + 43.735956824504974_lat);
+    params.coordinates.push_back(7.419247627258301_lon + 43.73574752168583_lat);
+    params.coordinates.push_back(7.419043779373169_lon + 43.73566224995717_lat);
+    params.coordinates.push_back(7.418732643127442_lon + 43.735406434042645_lat);
+    params.coordinates.push_back(7.418657541275024_lon + 43.735321161828274_lat);
+    params.coordinates.push_back(7.418593168258667_lon + 43.73521263337983_lat);
+    params.coordinates.push_back(7.418367862701416_lon + 43.73508084857086_lat);
+    params.coordinates.push_back(7.418346405029297_lon + 43.73484828643578_lat);
+    params.coordinates.push_back(7.4180567264556885_lon + 43.734437424456566_lat);
+    params.coordinates.push_back(7.417809963226318_lon + 43.73414284243448_lat);
+    params.coordinates.push_back(7.417863607406615_lon + 43.73375523230292_lat);
+    params.coordinates.push_back(7.417809963226318_lon + 43.73386376339265_lat);
+    params.coordinates.push_back(7.417895793914795_lon + 43.73365445325776_lat);
+    params.coordinates.push_back(7.418067455291747_lon + 43.73343739012297_lat);
+    params.coordinates.push_back(7.41803526878357_lon + 43.73319706930599_lat);
+    params.coordinates.push_back(7.418024539947509_lon + 43.73295674752463_lat);
+    params.coordinates.push_back(7.417906522750854_lon + 43.73284821479115_lat);
+    params.coordinates.push_back(7.417917251586914_lon + 43.7327551865773_lat);
+    params.coordinates.push_back(7.417434453964233_lon + 43.73281720540258_lat);
+    params.coordinates.push_back(7.4173808097839355_lon + 43.73307303237796_lat);
+    params.coordinates.push_back(7.41750955581665_lon + 43.73328234454499_lat);
+    params.coordinates.push_back(7.417563199996948_lon + 43.73352266501975_lat);
+    params.coordinates.push_back(7.41750955581665_lon + 43.733770736756355_lat);
+    params.coordinates.push_back(7.417466640472412_lon + 43.73409632935116_lat);
+    params.coordinates.push_back(7.417230606079102_lon + 43.73428238146768_lat);
+    params.coordinates.push_back(7.41724133491516_lon + 43.73405756842078_lat);
+    params.coordinates.push_back(7.4169838428497314_lon + 43.73449168940785_lat);
+    params.coordinates.push_back(7.41701602935791_lon + 43.734615723397525_lat);
+    params.coordinates.push_back(7.41704821586609_lon + 43.73487929477265_lat);
+    params.coordinates.push_back(7.41725206375122_lon + 43.734949063471895_lat);
+    params.coordinates.push_back(7.4173808097839355_lon + 43.73533666587628_lat);
+    params.coordinates.push_back(7.41750955581665_lon + 43.735623490040375_lat);
+    params.coordinates.push_back(7.417799234390259_lon + 43.73577852955704_lat);
+    params.coordinates.push_back(7.4180781841278085_lon + 43.735972328388435_lat);
+    params.coordinates.push_back(7.41850733757019_lon + 43.73608860738618_lat);
+    params.coordinates.push_back(7.418850660324096_lon + 43.736228141885455_lat);
+    params.coordinates.push_back(7.419086694717407_lon + 43.73636767605958_lat);
+    params.coordinates.push_back(7.419333457946777_lon + 43.73664674343239_lat);
+    params.coordinates.push_back(7.419633865356444_lon + 43.73676302112054_lat);
+    params.coordinates.push_back(7.419784069061279_lon + 43.737096349241845_lat);
+    params.coordinates.push_back(7.420030832290649_lon + 43.73720487427631_lat);
+    params.coordinates.push_back(7.419601678848267_lon + 43.73708084564945_lat);
+    params.coordinates.push_back(7.419333457946777_lon + 43.73708084564945_lat);
+    params.coordinates.push_back(7.419043779373169_lon + 43.737158363571325_lat);
+    params.coordinates.push_back(7.418915033340454_lon + 43.737305647346446_lat);
+    params.coordinates.push_back(7.41848587989807_lon + 43.7374916894919_lat);
+    params.coordinates.push_back(7.418271303176879_lon + 43.73746843425534_lat);
+    params.coordinates.push_back(7.417960166931152_lon + 43.73744517900973_lat);
+    params.coordinates.push_back(7.417885065078735_lon + 43.737212626056944_lat);
+    params.coordinates.push_back(7.417563199996948_lon + 43.73703433484817_lat);
+    params.coordinates.push_back(7.4173057079315186_lon + 43.73692580950463_lat);
+    params.coordinates.push_back(7.417144775390625_lon + 43.7367707729584_lat);
+    params.coordinates.push_back(7.416973114013672_lon + 43.73653821738638_lat);
+    params.coordinates.push_back(7.416855096817017_lon + 43.73639868360965_lat);
+    params.coordinates.push_back(7.4167799949646_lon + 43.736142870841206_lat);
+    params.coordinates.push_back(7.41675853729248_lon + 43.735848297208605_lat);
+    params.coordinates.push_back(7.416619062423706_lon + 43.73567000193752_lat);
+    params.coordinates.push_back(7.416543960571288_lon + 43.735406434042645_lat);
+    params.coordinates.push_back(7.416479587554932_lon + 43.73529790574875_lat);
+    params.coordinates.push_back(7.416415214538574_lon + 43.73515061703527_lat);
+    params.coordinates.push_back(7.416350841522218_lon + 43.73490255101476_lat);
+    params.coordinates.push_back(7.416340112686156_lon + 43.73475526132885_lat);
+    params.coordinates.push_back(7.416222095489501_lon + 43.73446068087028_lat);
+    params.coordinates.push_back(7.416243553161621_lon + 43.73430563794159_lat);
+    params.coordinates.push_back(7.416050434112548_lon + 43.73403431185051_lat);
+    params.coordinates.push_back(7.415814399719239_lon + 43.73382500231174_lat);
+    params.coordinates.push_back(7.415750026702881_lon + 43.73354592178871_lat);
+    params.coordinates.push_back(7.415513992309569_lon + 43.73347615145474_lat);
+    params.coordinates.push_back(7.415342330932617_lon + 43.733251335381205_lat);
 
     auto run_benchmark = [&](std::optional<double> radiusInMeters)
     {

--- a/src/nodejs/CMakeLists.txt
+++ b/src/nodejs/CMakeLists.txt
@@ -16,7 +16,7 @@ message(STATUS "Configuring node_osrm bindings for NodeJs ${NODEJS_VERSION}")
 
 
 add_nodejs_module(node_osrm node_osrm.cpp)
-set_target_properties(node_osrm PROPERTIES CXX_STANDARD 17)
+set_target_properties(node_osrm PROPERTIES CXX_STANDARD 20)
 # TODO: we disable clang-tidy for this target, because it causes errors in third-party NodeJs related headers
 set_target_properties(node_osrm PROPERTIES CXX_CLANG_TIDY "")
 # TODO: we turn off some warnings for this target, because it causes errors in third-party NodeJs related headers

--- a/src/util/coordinate_calculation.cpp
+++ b/src/util/coordinate_calculation.cpp
@@ -393,13 +393,13 @@ double computeArea(const std::vector<Coordinate> &polygon)
     // For closed curves it corresponds to the shoelace algorithm for polygon areas
     double area = 0.;
     auto first = polygon.begin();
-    auto previous_base = util::Coordinate{first->lon, ref_latitude};
+    Coordinate previous_base{first->lon, ref_latitude};
     auto previous_y = greatCircleDistance(previous_base, *first);
     for (++first; first != polygon.end(); ++first)
     {
         BOOST_ASSERT(first->lat >= ref_latitude);
 
-        const auto current_base = util::Coordinate{first->lon, ref_latitude};
+        const Coordinate current_base{first->lon, ref_latitude};
         const auto current_y = greatCircleDistance(current_base, *first);
         const auto chunk_area =
             greatCircleDistance(previous_base, current_base) * (previous_y + current_y);

--- a/unit_tests/engine/douglas_peucker.cpp
+++ b/unit_tests/engine/douglas_peucker.cpp
@@ -33,10 +33,7 @@ BOOST_AUTO_TEST_CASE(removed_middle_test)
         x       x
     */
     std::vector<util::Coordinate> coordinates = {
-        util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
-        util::Coordinate{util::FloatLongitude{12.5}, util::FloatLatitude{12.6096298302}},
-        util::Coordinate{util::FloatLongitude{20}, util::FloatLatitude{20}},
-        util::Coordinate{util::FloatLongitude{25}, util::FloatLatitude{5}}};
+        5_lon + 5_lat, 12.5_lon + 12.6096298302_lat, 20_lon + 20_lat, 25_lon + 5_lat};
 
     for (unsigned z = 0; z < detail::DOUGLAS_PEUCKER_THRESHOLDS_SIZE; z++)
     {
@@ -58,10 +55,7 @@ BOOST_AUTO_TEST_CASE(removed_middle_test_zoom_sensitive)
         x       x
     */
     std::vector<util::Coordinate> coordinates = {
-        util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
-        util::Coordinate{util::FloatLongitude{6}, util::FloatLatitude{6}},
-        util::Coordinate{util::FloatLongitude{20}, util::FloatLatitude{20}},
-        util::Coordinate{util::FloatLongitude{25}, util::FloatLatitude{5}}};
+        5_lon + 5_lat, 6_lon + 6_lat, 20_lon + 20_lat, 25_lon + 5_lat};
 
     // Coordinate 6,6 should start getting included at Z9 and higher
     // Note that 5,5->6,6->10,10 is *not* a straight line on the surface
@@ -98,15 +92,13 @@ BOOST_AUTO_TEST_CASE(remove_second_node_test)
                 |
                 x
         */
-        std::vector<util::Coordinate> input = {
-            util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{5}},
-            util::Coordinate{util::FloatLongitude{5 + delta_pixel_to_delta_degree(2, z)},
-                             util::FloatLatitude{5}},
-            util::Coordinate{util::FloatLongitude{10}, util::FloatLatitude{10}},
-            util::Coordinate{util::FloatLongitude{5}, util::FloatLatitude{15}},
-            util::Coordinate{util::FloatLongitude{5},
-                             util::FloatLatitude{15 + delta_pixel_to_delta_degree(2, z)}}};
-        BOOST_TEST_MESSAGE("Delta (" << z << "): " << delta_pixel_to_delta_degree(2, z));
+        double delta = delta_pixel_to_delta_degree(2, z);
+        std::vector<util::Coordinate> input = {5_lon + 5_lat,
+                                               5_lon + 5_lat + 1_lon * delta,
+                                               10_lon + 10_lat,
+                                               5_lon + 15_lat,
+                                               5_lon + 15_lat + 1_lat * delta};
+        BOOST_TEST_MESSAGE("Delta (" << z << "): " << delta);
         auto result = douglasPeucker(input, z);
         BOOST_CHECK_EQUAL(result.size(), 3);
         BOOST_CHECK_EQUAL(input[0], result[0]);

--- a/unit_tests/server/parameters_parser.cpp
+++ b/unit_tests/server/parameters_parser.cpp
@@ -16,6 +16,8 @@
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 
+using namespace osrm::util::literals;
+
 #define CHECK_EQUAL_RANGE(R1, R2)                                                                  \
     BOOST_CHECK_EQUAL_COLLECTIONS((R1).begin(), (R1).end(), (R2).begin(), (R2).end());
 
@@ -139,8 +141,7 @@ BOOST_AUTO_TEST_CASE(invalid_table_urls)
 BOOST_AUTO_TEST_CASE(valid_route_segment_hint)
 {
     engine::PhantomNode reference_node;
-    reference_node.input_location =
-        util::Coordinate(util::FloatLongitude{7.432251}, util::FloatLatitude{43.745995});
+    reference_node.input_location = 7.432251_lon + 43.745995_lat;
     engine::SegmentHint reference_segment_hint{reference_node, 0x1337};
     auto encoded_hint = reference_segment_hint.ToBase64();
     auto seg_hint = engine::SegmentHint::FromBase64(encoded_hint);
@@ -150,8 +151,7 @@ BOOST_AUTO_TEST_CASE(valid_route_segment_hint)
 
 BOOST_AUTO_TEST_CASE(valid_route_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     RouteParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -278,9 +278,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_5.coordinates, result_5->coordinates);
     CHECK_EQUAL_RANGE_OF_HINTS(reference_5.hints, result_5->hints);
 
-    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{0}, util::FloatLatitude{1}},
-                                              {util::FloatLongitude{2}, util::FloatLatitude{3}},
-                                              {util::FloatLongitude{4}, util::FloatLatitude{5}}};
+    std::vector<util::Coordinate> coords_2 = {0_lon + 1_lat, 2_lon + 3_lat, 4_lon + 5_lat};
 
     RouteParameters reference_6{};
     reference_6.coordinates = coords_2;
@@ -331,10 +329,8 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
     CHECK_EQUAL_RANGE(reference_9.radiuses, result_9->radiuses);
 
     // Some Hint's are empty
-    std::vector<util::Coordinate> coords_3 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}},
-                                              {util::FloatLongitude{5}, util::FloatLatitude{6}},
-                                              {util::FloatLongitude{7}, util::FloatLatitude{8}}};
+    std::vector<util::Coordinate> coords_3 = {
+        1_lon + 2_lat, 3_lon + 4_lat, 5_lon + 6_lat, 7_lon + 8_lat};
 
     engine::PhantomNode phantom_3;
     phantom_3.input_location = coords_3[0];
@@ -546,8 +542,7 @@ BOOST_AUTO_TEST_CASE(valid_route_urls)
 
 BOOST_AUTO_TEST_CASE(valid_table_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     TableParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -660,8 +655,7 @@ BOOST_AUTO_TEST_CASE(valid_table_urls)
 
 BOOST_AUTO_TEST_CASE(valid_match_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     MatchParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -684,9 +678,7 @@ BOOST_AUTO_TEST_CASE(valid_match_urls)
     CHECK_EQUAL_RANGE(reference_2.approaches, result_2->approaches);
     CHECK_EQUAL_RANGE(reference_2.coordinates, result_2->coordinates);
 
-    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}},
-                                              {util::FloatLongitude{5}, util::FloatLatitude{6}}};
+    std::vector<util::Coordinate> coords_2 = {1_lon + 2_lat, 3_lon + 4_lat, 5_lon + 6_lat};
 
     MatchParameters reference_3{};
     reference_3.coordinates = coords_2;
@@ -703,8 +695,7 @@ BOOST_AUTO_TEST_CASE(valid_match_urls)
 
 BOOST_AUTO_TEST_CASE(invalid_match_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     MatchParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -716,8 +707,7 @@ BOOST_AUTO_TEST_CASE(invalid_match_urls)
     CHECK_EQUAL_RANGE(reference_1.approaches, result_1->approaches);
     CHECK_EQUAL_RANGE(reference_1.coordinates, result_1->coordinates);
 
-    std::vector<util::Coordinate> coords_2 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_2 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     MatchParameters reference_2{};
     reference_2.coordinates = coords_2;
@@ -728,7 +718,7 @@ BOOST_AUTO_TEST_CASE(invalid_match_urls)
 
 BOOST_AUTO_TEST_CASE(valid_nearest_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat};
 
     NearestParameters reference_1{};
     reference_1.coordinates = coords_1;
@@ -776,8 +766,7 @@ BOOST_AUTO_TEST_CASE(valid_tile_urls)
 
 BOOST_AUTO_TEST_CASE(valid_trip_urls)
 {
-    std::vector<util::Coordinate> coords_1 = {{util::FloatLongitude{1}, util::FloatLatitude{2}},
-                                              {util::FloatLongitude{3}, util::FloatLatitude{4}}};
+    std::vector<util::Coordinate> coords_1 = {1_lon + 2_lat, 3_lon + 4_lat};
 
     TripParameters reference_1{};
     reference_1.coordinates = coords_1;

--- a/unit_tests/server/url_parser.cpp
+++ b/unit_tests/server/url_parser.cpp
@@ -21,6 +21,7 @@ BOOST_AUTO_TEST_SUITE(api_url_parser)
 
 using namespace osrm;
 using namespace osrm::server;
+using namespace osrm::util::literals;
 
 // returns distance to front
 std::size_t testInvalidURL(std::string url)
@@ -64,7 +65,7 @@ BOOST_AUTO_TEST_CASE(valid_urls)
 
     // one coordinate
     std::vector<util::Coordinate> coords_3 = {
-        util::Coordinate{util::FloatLongitude{0}, util::FloatLatitude{1}},
+        0_lon + 1_lat,
     };
     api::ParsedURL reference_3{"route", 1, "profile", "0,1", 18UL};
     auto result_3 = api::parseURL("/route/v1/profile/0,1");

--- a/unit_tests/util/coordinate_calculation.cpp
+++ b/unit_tests/util/coordinate_calculation.cpp
@@ -19,111 +19,111 @@ BOOST_AUTO_TEST_CASE(compute_angle)
 {
     // Simple cases
     // North-South straight line
-    Coordinate first(FloatLongitude{1}, FloatLatitude{-1});
-    Coordinate middle(FloatLongitude{1}, FloatLatitude{0});
-    Coordinate end(FloatLongitude{1}, FloatLatitude{1});
+    Coordinate first{1_lon - 1_lat};
+    Coordinate middle{1_lon + 0_lat};
+    Coordinate end{1_lon + 1_lat};
     auto angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // North-South-North u-turn
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
-    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    first = 1_lon + 0_lat;
+    middle = 1_lon + 1_lat;
+    end = 1_lon + 0_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // East-west straight lines are harder, *simple* coordinates only
     // work at the equator.  For other locations, we need to follow
     // a rhumb line.
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
-    middle = Coordinate(FloatLongitude{2}, FloatLatitude{0});
-    end = Coordinate(FloatLongitude{3}, FloatLatitude{0});
+    first = 1_lon;
+    middle = 2_lon;
+    end = 3_lon;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // East-West-East u-turn
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{0});
-    middle = Coordinate(FloatLongitude{2}, FloatLatitude{0});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{0});
+    first = 1_lon;
+    middle = 2_lon;
+    end = 1_lon;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // 90 degree left turn
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{0}, FloatLatitude{2});
+    first = 1_lon + 1_lat;
+    middle = 0_lon + 1_lat;
+    end = 0_lon + 2_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 90);
 
     // 90 degree right turn
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{0}, FloatLatitude{0});
+    first = 1_lon + 1_lat;
+    middle = 0_lon + 1_lat;
+    end = 0_lon + 0_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 270);
 
     // Weird cases
     // Crossing both the meridians
-    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    middle = Coordinate(FloatLongitude{0}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{-1});
+    first = -1_lon - 1_lat;
+    middle = 0_lon + 1_lat;
+    end = 1_lon - 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_CLOSE(angle, 53.1, 0.2);
 
     // All coords in the same spot
-    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    end = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    first = -1_lon - 1_lat;
+    middle = -1_lon - 1_lat;
+    end = -1_lon - 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot, then heading north-east
-    first = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    first = -1_lon - 1_lat;
+    middle = -1_lon - 1_lat;
+    end = 1_lon + 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot, then heading west
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{2}, FloatLatitude{1});
+    first = 1_lon + 1_lat;
+    middle = 1_lon + 1_lat;
+    end = 2_lon + 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First two coords in the same spot then heading north
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{2});
+    first = 1_lon + 1_lat;
+    middle = 1_lon + 1_lat;
+    end = 1_lon + 2_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // Second two coords in the same spot
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    end = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
+    first = 1_lon + 1_lat;
+    middle = -1_lon - 1_lat;
+    end = -1_lon - 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // First and last coords on the same spot
-    first = Coordinate(FloatLongitude{1}, FloatLatitude{1});
-    middle = Coordinate(FloatLongitude{-1}, FloatLatitude{-1});
-    end = Coordinate(FloatLongitude{1}, FloatLatitude{1});
+    first = 1_lon + 1_lat;
+    middle = -1_lon - 1_lat;
+    end = 1_lon + 1_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 0);
 
     // Check the antimeridian
-    first = Coordinate(FloatLongitude{180}, FloatLatitude{90});
-    middle = Coordinate(FloatLongitude{180}, FloatLatitude{0});
-    end = Coordinate(FloatLongitude{180}, FloatLatitude{-90});
+    first = 180_lon + 90_lat;
+    middle = 180_lon + 0_lat;
+    end = 180_lon - 90_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 
     // Tiny changes below our calculation resolution
     // This should be equivalent to having two points on the same spot.
-    first = Coordinate{FloatLongitude{0}, FloatLatitude{0}};
-    middle = Coordinate{FloatLongitude{1}, FloatLatitude{0}};
-    end = Coordinate{FloatLongitude{1 + std::numeric_limits<double>::epsilon()}, FloatLatitude{0}};
+    first = 0_lon + 0_lat;
+    middle = 1_lon + 0_lat;
+    end = 1_lon + 1_lon * std::numeric_limits<double>::epsilon() + 0_lat;
     angle = coordinate_calculation::computeAngle(first, middle, end);
     BOOST_CHECK_EQUAL(angle, 180);
 }
@@ -131,20 +131,20 @@ BOOST_AUTO_TEST_CASE(compute_angle)
 BOOST_AUTO_TEST_CASE(invalid_values)
 {
     // Invalid values for unsafe types
-    BOOST_CHECK_THROW(coordinate_calculation::computeAngle(
-                          Coordinate(UnsafeFloatLongitude{0}, UnsafeFloatLatitude{0}),
-                          Coordinate(UnsafeFloatLongitude{1}, UnsafeFloatLatitude{0}),
-                          Coordinate(UnsafeFloatLongitude{std::numeric_limits<double>::max()},
-                                     UnsafeFloatLatitude{0})),
-                      boost::numeric::positive_overflow);
+    BOOST_CHECK_THROW(
+        coordinate_calculation::computeAngle(
+            {UnsafeFloatLongitude{0}, UnsafeFloatLatitude{0}},
+            {UnsafeFloatLongitude{1}, UnsafeFloatLatitude{0}},
+            {UnsafeFloatLongitude{std::numeric_limits<double>::max()}, UnsafeFloatLatitude{0}}),
+        boost::numeric::positive_overflow);
 }
 
 // Regression test for bug captured in #1347
 BOOST_AUTO_TEST_CASE(regression_test_1347)
 {
-    Coordinate u(FloatLongitude{-100}, FloatLatitude{10});
-    Coordinate v(FloatLongitude{-100.002}, FloatLatitude{10.001});
-    Coordinate q(FloatLongitude{-100.001}, FloatLatitude{10.002});
+    Coordinate u{-100_lon + 10_lat};
+    Coordinate v{-100.002_lon + 10.001_lat};
+    Coordinate q{-100.001_lon + 10.002_lat};
 
     double d1 = coordinate_calculation::perpendicularDistance(u, v, q);
 
@@ -172,9 +172,9 @@ BOOST_AUTO_TEST_CASE(regression_point_on_segment)
     //  |
     //  |
     //  |                           s
-    FloatCoordinate input{FloatLongitude{55.995715}, FloatLatitude{48.332711}};
-    FloatCoordinate start{FloatLongitude{74.140427}, FloatLatitude{-180}};
-    FloatCoordinate target{FloatLongitude{53.041084}, FloatLatitude{77.21011}};
+    FloatCoordinate input{55.995715_lon + 48.332711_lat};
+    FloatCoordinate start{74.140427_lon - 180_lat};
+    FloatCoordinate target{53.041084_lon + 77.21011_lat};
 
     FloatCoordinate nearest;
     double ratio;
@@ -198,11 +198,9 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
     //  |
     //  s
     auto result_1 =
-        coordinate_calculation::projectPointOnSegment({FloatLongitude{0}, FloatLatitude{0}},
-                                                      {FloatLongitude{0}, FloatLatitude{2}},
-                                                      {FloatLongitude{2}, FloatLatitude{1}});
+        coordinate_calculation::projectPointOnSegment(0_lon + 0_lat, 0_lon + 2_lat, 2_lon + 1_lat);
     auto reference_ratio_1 = 0.5;
-    auto reference_point_1 = FloatCoordinate{FloatLongitude{0}, FloatLatitude{1}};
+    auto reference_point_1 = FloatCoordinate{0_lon + 1_lat};
     BOOST_CHECK_EQUAL(result_1.first, reference_ratio_1);
     BOOST_CHECK_EQUAL(result_1.second.lon, reference_point_1.lon);
     BOOST_CHECK_EQUAL(result_1.second.lat, reference_point_1.lat);
@@ -214,12 +212,10 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
     //  |
     //  |
     //  s
-    auto result_2 =
-        coordinate_calculation::projectPointOnSegment({FloatLongitude{0.}, FloatLatitude{0.}},
-                                                      {FloatLongitude{0}, FloatLatitude{2}},
-                                                      {FloatLongitude{0}, FloatLatitude{3}});
+    auto result_2 = coordinate_calculation::projectPointOnSegment(
+        0._lon + 0._lat, 0_lon + 2_lat, 0_lon + 3_lat);
     auto reference_ratio_2 = 1.;
-    auto reference_point_2 = FloatCoordinate{FloatLongitude{0}, FloatLatitude{2}};
+    auto reference_point_2 = FloatCoordinate{0_lon + 2_lat};
     BOOST_CHECK_EQUAL(result_2.first, reference_ratio_2);
     BOOST_CHECK_EQUAL(result_2.second.lon, reference_point_2.lon);
     BOOST_CHECK_EQUAL(result_2.second.lat, reference_point_2.lat);
@@ -231,12 +227,10 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
     //  s
     //  :
     //  i
-    auto result_3 =
-        coordinate_calculation::projectPointOnSegment({FloatLongitude{0.}, FloatLatitude{0.}},
-                                                      {FloatLongitude{0}, FloatLatitude{2}},
-                                                      {FloatLongitude{0}, FloatLatitude{-1}});
+    auto result_3 = coordinate_calculation::projectPointOnSegment(
+        0._lon + 0._lat, 0_lon + 2_lat, 0_lon - 1_lat);
     auto reference_ratio_3 = 0.;
-    auto reference_point_3 = FloatCoordinate{FloatLongitude{0}, FloatLatitude{0}};
+    auto reference_point_3 = FloatCoordinate{0_lon + 0_lat};
     BOOST_CHECK_EQUAL(result_3.first, reference_ratio_3);
     BOOST_CHECK_EQUAL(result_3.second.lon, reference_point_3.lon);
     BOOST_CHECK_EQUAL(result_3.second.lat, reference_point_3.lat);
@@ -248,11 +242,9 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
     // s
     //
     auto result_4 = coordinate_calculation::projectPointOnSegment(
-        {FloatLongitude{0}, FloatLatitude{0}},
-        {FloatLongitude{1}, FloatLatitude{1}},
-        {FloatLongitude{0.5 + 0.1}, FloatLatitude{0.5 - 0.1}});
+        0_lon + 0_lat, 1_lon + 1_lat, {FloatLongitude{0.5 + 0.1}, FloatLatitude{0.5 - 0.1}});
     auto reference_ratio_4 = 0.5;
-    auto reference_point_4 = FloatCoordinate{FloatLongitude{0.5}, FloatLatitude{0.5}};
+    auto reference_point_4 = FloatCoordinate{0.5_lon + 0.5_lat};
     BOOST_CHECK_EQUAL(result_4.first, reference_ratio_4);
     BOOST_CHECK_EQUAL(result_4.second.lon, reference_point_4.lon);
     BOOST_CHECK_EQUAL(result_4.second.lat, reference_point_4.lat);
@@ -260,56 +252,56 @@ BOOST_AUTO_TEST_CASE(point_on_segment)
 
 BOOST_AUTO_TEST_CASE(circleCenter)
 {
-    Coordinate a(FloatLongitude{-100.}, FloatLatitude{10.});
-    Coordinate b(FloatLongitude{-100.002}, FloatLatitude{10.001});
-    Coordinate c(FloatLongitude{-100.001}, FloatLatitude{10.002});
+    Coordinate a{-100._lon + 10._lat};
+    Coordinate b{-100.002_lon + 10.001_lat};
+    Coordinate c{-100.001_lon + 10.002_lat};
 
     auto result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-100.0008333}, FloatLatitude{10.0008333}));
+    BOOST_CHECK_EQUAL(*result, -100.0008333_lon + 10.0008333_lat);
 
     // Co-linear longitude
-    a = Coordinate(FloatLongitude{-100.}, FloatLatitude{10.});
-    b = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.001});
-    c = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.002});
+    a = -100._lon + 10._lat;
+    b = -100.001_lon + 10.001_lat;
+    c = -100.001_lon + 10.002_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-99.9995}, FloatLatitude{10.0015}));
+    BOOST_CHECK_EQUAL(*result, -99.9995_lon + 10.0015_lat);
 
     // Co-linear longitude, impossible to calculate
-    a = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.});
-    b = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.001});
-    c = Coordinate(FloatLongitude{-100.001}, FloatLatitude{10.002});
+    a = -100.001_lon + 10._lat;
+    b = -100.001_lon + 10.001_lat;
+    c = -100.001_lon + 10.002_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 
     // Co-linear latitude, this is a real case that failed
-    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147101});
-    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147101});
-    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
+    a = -112.096234_lon + 41.147101_lat;
+    b = -112.096606_lon + 41.147101_lat;
+    c = -112.096419_lon + 41.147259_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-112.09642}, FloatLatitude{41.1470705}));
+    BOOST_CHECK_EQUAL(*result, -112.09642_lon + 41.147071_lat);
 
     // Co-linear latitude, variation
-    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147101});
-    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147259});
-    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
+    a = -112.096234_lon + 41.147101_lat;
+    b = -112.096606_lon + 41.147259_lat;
+    c = -112.096419_lon + 41.147259_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(result);
-    BOOST_CHECK_EQUAL(*result, Coordinate(FloatLongitude{-112.0965125}, FloatLatitude{41.1469622}));
+    BOOST_CHECK_EQUAL(*result, -112.096513_lon + 41.146962_lat);
 
     // Co-linear latitude, impossible to calculate
-    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147259});
-    b = Coordinate(FloatLongitude{-112.096606}, FloatLatitude{41.147259});
-    c = Coordinate(FloatLongitude{-112.096419}, FloatLatitude{41.147259});
+    a = -112.096234_lon + 41.147259_lat;
+    b = -112.096606_lon + 41.147259_lat;
+    c = -112.096419_lon + 41.147259_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 
     // Out of bounds
-    a = Coordinate(FloatLongitude{-112.096234}, FloatLatitude{41.147258});
-    b = Coordinate(FloatLongitude{-112.106606}, FloatLatitude{41.147259});
-    c = Coordinate(FloatLongitude{-113.096419}, FloatLatitude{41.147258});
+    a = -112.096234_lon + 41.147258_lat;
+    b = -112.106606_lon + 41.147259_lat;
+    c = -113.096419_lon + 41.147258_lat;
     result = coordinate_calculation::circleCenter(a, b, c);
     BOOST_CHECK(!result);
 }
@@ -320,8 +312,8 @@ BOOST_AUTO_TEST_CASE(squaredEuclideanDistance)
     // Overflow happens when left hand side values are smaller than right hand side values,
     // then `lhs - rhs` will be negative but stored in a uint64_t (wraps around).
 
-    Coordinate lhs(FloatLongitude{-180}, FloatLatitude{-90});
-    Coordinate rhs(FloatLongitude{180}, FloatLatitude{90});
+    Coordinate lhs{-180_lon - 90_lat};
+    Coordinate rhs{+180_lon + 90_lat};
 
     const auto result = coordinate_calculation::squaredEuclideanDistance(lhs, rhs);
 
@@ -333,7 +325,7 @@ BOOST_AUTO_TEST_CASE(vertical_regression)
     // check a vertical line for its bearing
     std::vector<Coordinate> coordinates;
     for (std::size_t i = 0; i < 100; ++i)
-        coordinates.push_back(Coordinate(FloatLongitude{0.0}, FloatLatitude{i / 100.0}));
+        coordinates.push_back(1_lat * (i / 100.0));
 
     const auto regression =
         util::coordinate_calculation::leastSquareRegression(coordinates.begin(), coordinates.end());
@@ -348,9 +340,9 @@ BOOST_AUTO_TEST_CASE(sinus_curve)
     // create a full sinus curve, sampled in 3.6 degree
     std::vector<Coordinate> coordinates;
     for (std::size_t i = 0; i < 360; ++i)
-        coordinates.push_back(Coordinate(
+        coordinates.emplace_back(
             FloatLongitude{i / 360.0},
-            FloatLatitude{sin(util::coordinate_calculation::detail::degToRad(i / 360.0))}));
+            FloatLatitude{sin(util::coordinate_calculation::detail::degToRad(i / 360.0))});
 
     const auto regression =
         util::coordinate_calculation::leastSquareRegression(coordinates.begin(), coordinates.end());
@@ -365,13 +357,12 @@ BOOST_AUTO_TEST_CASE(parallel_lines_slight_offset)
 {
     std::vector<Coordinate> coordinates_lhs;
     for (std::size_t i = 0; i < 100; ++i)
-        coordinates_lhs.push_back(Coordinate(util::FloatLongitude{(50 - (rand() % 101)) / 100000.0},
-                                             util::FloatLatitude{i / 100000.0}));
+        coordinates_lhs.emplace_back(util::FloatLongitude{(50 - (rand() % 101)) / 100000.0},
+                                     util::FloatLatitude{i / 100000.0});
     std::vector<Coordinate> coordinates_rhs;
     for (std::size_t i = 0; i < 100; ++i)
-        coordinates_rhs.push_back(
-            Coordinate(util::FloatLongitude{(150 - (rand() % 101)) / 100000.0},
-                       util::FloatLatitude{i / 100000.0}));
+        coordinates_rhs.emplace_back(util::FloatLongitude{(150 - (rand() % 101)) / 100000.0},
+                                     util::FloatLatitude{i / 100000.0});
 
     const auto are_parallel = util::coordinate_calculation::areParallel(coordinates_lhs.begin(),
                                                                         coordinates_lhs.end(),
@@ -382,9 +373,9 @@ BOOST_AUTO_TEST_CASE(parallel_lines_slight_offset)
 
 BOOST_AUTO_TEST_CASE(consistent_invalid_bearing_result)
 {
-    const auto pos1 = Coordinate(util::FloatLongitude{0.}, util::FloatLatitude{0.});
-    const auto pos2 = Coordinate(util::FloatLongitude{5.}, util::FloatLatitude{5.});
-    const auto pos3 = Coordinate(util::FloatLongitude{-5.}, util::FloatLatitude{-5.});
+    const Coordinate pos1{0._lon + 0._lat};
+    const Coordinate pos2{5._lon + 5._lat};
+    const Coordinate pos3{-5._lon - 5._lat};
 
     BOOST_CHECK_EQUAL(0., util::coordinate_calculation::bearing(pos1, pos1));
     BOOST_CHECK_EQUAL(0., util::coordinate_calculation::bearing(pos2, pos2));
@@ -394,9 +385,9 @@ BOOST_AUTO_TEST_CASE(consistent_invalid_bearing_result)
 // Regression test for bug captured in #3516
 BOOST_AUTO_TEST_CASE(regression_test_3516)
 {
-    Coordinate u(FloatLongitude{-73.989687}, FloatLatitude{40.752288});
-    Coordinate v(FloatLongitude{-73.990134}, FloatLatitude{40.751658});
-    Coordinate q(FloatLongitude{-73.99039}, FloatLatitude{40.75171});
+    const Coordinate u{-73.989687_lon + 40.752288_lat};
+    const Coordinate v{-73.990134_lon + 40.751658_lat};
+    const Coordinate q{-73.99039_lon + 40.75171_lat};
 
     BOOST_CHECK_EQUAL(Coordinate{web_mercator::toWGS84(web_mercator::fromWGS84(u))}, u);
     BOOST_CHECK_EQUAL(Coordinate{web_mercator::toWGS84(web_mercator::fromWGS84(v))}, v);
@@ -414,22 +405,22 @@ BOOST_AUTO_TEST_CASE(computeArea)
     using osrm::util::coordinate_calculation::computeArea;
 
     //
-    auto rhombus = std::vector<Coordinate>{{FloatLongitude{.00}, FloatLatitude{.00}},
-                                           {FloatLongitude{.01}, FloatLatitude{.01}},
-                                           {FloatLongitude{.02}, FloatLatitude{.00}},
-                                           {FloatLongitude{.01}, FloatLatitude{-.01}},
-                                           {FloatLongitude{.00}, FloatLatitude{.00}}};
+    auto rhombus = std::vector<Coordinate>{.00_lon + .00_lat,
+                                           .01_lon + .01_lat,
+                                           .02_lon + .00_lat,
+                                           .01_lon - .01_lat,
+                                           .00_lon + .00_lat};
 
     BOOST_CHECK_CLOSE(2 * 1109.462 * 1109.462, computeArea(rhombus), 1e-3);
 
     // edge cases
-    auto self_intersection = std::vector<Coordinate>{{FloatLongitude{.00}, FloatLatitude{.00}},
-                                                     {FloatLongitude{.00}, FloatLatitude{.02}},
-                                                     {FloatLongitude{.01}, FloatLatitude{.01}},
-                                                     {FloatLongitude{.02}, FloatLatitude{.00}},
-                                                     {FloatLongitude{.02}, FloatLatitude{.02}},
-                                                     {FloatLongitude{.01}, FloatLatitude{.01}},
-                                                     {FloatLongitude{.00}, FloatLatitude{.00}}};
+    auto self_intersection = std::vector<Coordinate>{.00_lon + .00_lat,
+                                                     .00_lon + .02_lat,
+                                                     .01_lon + .01_lat,
+                                                     .02_lon + .00_lat,
+                                                     .02_lon + .02_lat,
+                                                     .01_lon + .01_lat,
+                                                     .00_lon + .00_lat};
     BOOST_CHECK(computeArea(self_intersection) < 1e-3);
     BOOST_CHECK_CLOSE(0, computeArea({}), 1e-3);
 }

--- a/unit_tests/util/static_rtree.cpp
+++ b/unit_tests/util/static_rtree.cpp
@@ -101,7 +101,7 @@ template <unsigned NUM_NODES, unsigned NUM_EDGES> struct RandomGraphFixture
         {
             int lon = lon_udist(g);
             int lat = lat_udist(g);
-            coords.emplace_back(Coordinate(FixedLongitude{lon}, FixedLatitude{lat}));
+            coords.emplace_back(FixedLongitude{lon}, FixedLatitude{lat});
         }
 
         std::uniform_int_distribution<> edge_udist(0, coords.size() - 1);

--- a/unit_tests/util/viewport.cpp
+++ b/unit_tests/util/viewport.cpp
@@ -11,11 +11,9 @@ using namespace osrm::util;
 
 BOOST_AUTO_TEST_CASE(zoom_level_test)
 {
-    BOOST_CHECK_EQUAL(
-        viewport::getFittedZoom(
-            Coordinate(FloatLongitude{5.668343999999995}, FloatLatitude{45.111511000000014}),
-            Coordinate(FloatLongitude{5.852471999999996}, FloatLatitude{45.26800200000002})),
-        12);
+    BOOST_CHECK_EQUAL(viewport::getFittedZoom(5.668343999999995_lon + 45.111511000000014_lat,
+                                              5.852471999999996_lon + 45.26800200000002_lat),
+                      12);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue

This PR introduces User-Defined Literals for coordinates, eg. you can now write:

```42.123456_lon + 69.123456_lat```

instead of

```FloatCoordinate{FloatLongitude{42.123456}, FloatLatitude{69.123456}});```

`_lon` and `_lat` are user-defined suffixes that yield real and imaginary complex numbers respectively. You can add those to form a complex number that converts into a `Coordinate` or `FloatCoordinate`.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md))
 - [ ] review
 - [ ] adjust for comments
